### PR TITLE
Use relative path

### DIFF
--- a/lib/face.js
+++ b/lib/face.js
@@ -17,8 +17,8 @@ function drawLandmark(ctx, landmark, ops = {}) {
 }
 
 export async function faceDetector(canvas, ctx) {
-  await faceapi.nets.ssdMobilenetv1.loadFromUri("/weights");
-  await faceapi.nets.faceLandmark68TinyNet.loadFromUri("/weights");
+  await faceapi.nets.ssdMobilenetv1.loadFromUri("weights");
+  await faceapi.nets.faceLandmark68TinyNet.loadFromUri("weights");
 
   const results = await faceapi
     .detectSingleFace(canvas)


### PR DESCRIPTION
Loading models uses absolute path. It fails on your current deployment at javier.xyz/pintr